### PR TITLE
Add Chromex Predict Pro landing page and dark trading UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,16 +5,38 @@ app = Flask(__name__)
 
 @app.route("/")
 def home():
-    product = {
-        "name": "Jungle Friends Student Notebook",
-        "tagline": "Colorful, kid-friendly notebook for school and daily writing.",
-        "price": "$4.99",
-        "size": "A4",
-        "pages": "172 ruled pages",
-        "cover": "Gloss laminated soft cover",
-        "theme": "Cute jungle animal artwork for students",
+    platform = {
+        "name": "Chromex Predict Pro",
+        "tagline": "Professional color prediction trading platform built for fast decisions and transparent analytics.",
+        "cta": "Start Trading",
+        "trust_note": "Trusted by 25,000+ active traders",
+        "daily_volume": "$2.4M",
+        "win_rate": "87.3%",
+        "avg_payout": "1.92x",
     }
-    return render_template("index.html", product=product)
+
+    markets = [
+        {
+            "name": "Emerald Sprint",
+            "window": "30 sec round",
+            "trend": "Green momentum +12%",
+            "payout": "1.8x",
+        },
+        {
+            "name": "Crimson Pulse",
+            "window": "60 sec round",
+            "trend": "Red reversal setup",
+            "payout": "2.1x",
+        },
+        {
+            "name": "Violet Edge",
+            "window": "90 sec round",
+            "trend": "High-volatility breakout",
+            "payout": "2.4x",
+        },
+    ]
+
+    return render_template("index.html", platform=platform, markets=markets)
 
 
 if __name__ == "__main__":

--- a/index.html
+++ b/index.html
@@ -3,44 +3,53 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jungle Friends Student Notebook | Product Page</title>
+    <title>Chromex Predict Pro | Color Prediction Trading</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="static/styles.css" />
   </head>
   <body>
+    <header class="topbar">
+      <div class="brand">Chromex Predict Pro</div>
+      <nav>
+        <a href="#markets">Markets</a>
+        <a href="#features">Features</a>
+        <a href="#start">Get Started</a>
+      </nav>
+      <button class="outline-btn">Login</button>
+    </header>
+
     <main class="page">
       <section class="hero">
-        <div class="badge">Back to School Special</div>
-        <h1>Jungle Friends Student Notebook</h1>
-        <p class="tagline">Colorful, kid-friendly notebook for school and daily writing.</p>
+        <p class="eyebrow">Live Color Prediction Exchange</p>
+        <h1>Trade color outcomes with confidence and speed.</h1>
+        <p class="tagline">
+          Professional color prediction trading platform built for fast decisions and transparent analytics.
+        </p>
 
-        <div class="price-card">
-          <span>Now Available</span>
-          <strong>$4.99</strong>
-          <small>Per notebook</small>
+        <div class="hero-actions">
+          <button>Start Trading</button>
+          <span class="trust">Trusted by 25,000+ active traders</span>
         </div>
-
-        <ul class="features">
-          <li><span>Size:</span> A4</li>
-          <li><span>Pages:</span> 172 ruled pages</li>
-          <li><span>Cover:</span> Gloss laminated soft cover</li>
-          <li><span>Theme:</span> Cute jungle animal artwork for students</li>
-        </ul>
-
-        <button>Order Now</button>
       </section>
 
-      <section class="preview" aria-label="Notebook visual preview">
-        <div class="mock-cover">
-          <div class="cover-title">STUDENT</div>
-          <p>Friends of the jungle have gathered to celebrate.</p>
-          <h2>Notebook</h2>
-        </div>
+      <section class="stats" aria-label="Key platform metrics">
+        <article>
+          <p>Daily Volume</p>
+          <strong>$2.4M</strong>
+        </article>
+        <article>
+          <p>Success Signals</p>
+          <strong>87.3%</strong>
+        </article>
+        <article>
+          <p>Average Payout</p>
+          <strong>1.92x</strong>
+        </article>
       </section>
     </main>
   </body>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,10 +1,12 @@
 :root {
-  --bg: #f2faf4;
-  --primary: #1c7c54;
-  --accent: #f6a23a;
-  --text: #13231a;
-  --muted: #506258;
-  --card: #ffffff;
+  --bg: #060a16;
+  --surface: #111830;
+  --surface-2: #1a2342;
+  --primary: #5cf6d0;
+  --accent: #7d84ff;
+  --text: #eaf0ff;
+  --muted: #9ea7c3;
+  --line: #2b345b;
 }
 
 * {
@@ -16,150 +18,188 @@ body {
   min-height: 100vh;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--text);
-  background: radial-gradient(circle at top left, #d6f6df 0%, var(--bg) 45%, #eef6ff 100%);
+  background: radial-gradient(circle at 15% 10%, #1a2550 0%, #060a16 50%, #03050f 100%);
+}
+
+.topbar,
+.page {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.topbar {
+  padding: 1.2rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand {
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+nav {
+  display: flex;
+  gap: 1.2rem;
+}
+
+nav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.outline-btn,
+button {
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-weight: 700;
+  border-radius: 12px;
+}
+
+.outline-btn {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--line);
+  padding: 0.55rem 1rem;
 }
 
 .page {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem;
+  padding: 2rem 0 3rem;
   display: grid;
-  gap: 2rem;
-  grid-template-columns: 1.1fr 0.9fr;
-  align-items: center;
+  gap: 1.4rem;
+}
+
+.hero {
+  background: linear-gradient(120deg, #1a2342 0%, #0e1530 100%);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  padding: 2rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 0.85rem;
 }
 
 .hero h1 {
+  margin: 0.75rem 0;
   font-size: clamp(2rem, 4vw, 3rem);
-  margin: 0.5rem 0;
-}
-
-.badge {
-  display: inline-block;
-  background: #def9e8;
-  color: var(--primary);
-  font-weight: 700;
-  padding: 0.35rem 0.8rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  letter-spacing: 0.03em;
+  max-width: 20ch;
 }
 
 .tagline {
   color: var(--muted);
-  max-width: 42ch;
+  max-width: 58ch;
   line-height: 1.6;
 }
 
-.price-card {
-  margin-top: 1.2rem;
-  background: var(--card);
-  border: 1px solid #d9e8dd;
-  border-radius: 16px;
-  width: fit-content;
-  padding: 0.9rem 1.1rem;
-  display: grid;
-  box-shadow: 0 10px 30px rgba(17, 49, 34, 0.08);
-}
-
-.price-card strong {
-  color: var(--primary);
-  font-size: 2rem;
-}
-
-.features {
-  margin: 1.6rem 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.65rem;
-}
-
-.features span {
-  font-weight: 700;
+.hero-actions {
+  margin-top: 1.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  align-items: center;
 }
 
 button {
-  background: linear-gradient(135deg, var(--accent), #ffbc65);
-  border: none;
-  color: #3d2407;
-  font-weight: 800;
-  font-size: 1rem;
-  padding: 0.85rem 1.5rem;
-  border-radius: 12px;
-  cursor: pointer;
+  background: linear-gradient(130deg, var(--primary), #87ffe5);
+  color: #02241d;
+  padding: 0.75rem 1.15rem;
 }
 
-.preview {
+.trust {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.stats {
   display: grid;
-  place-items: center;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
 }
 
-.mock-cover {
-  width: min(100%, 380px);
-  aspect-ratio: 2 / 3;
-  border-radius: 22px;
+.stats article,
+.market-card,
+.features,
+.cta {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 16px;
   padding: 1.2rem;
-  background: linear-gradient(180deg, #b4edd1 0%, #89d39e 50%, #73b987 100%);
-  box-shadow: 0 24px 60px rgba(16, 62, 38, 0.3);
-  position: relative;
-  overflow: hidden;
 }
 
-.mock-cover::before,
-.mock-cover::after {
-  content: "";
-  position: absolute;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.18);
-}
-
-.mock-cover::before {
-  width: 220px;
-  height: 220px;
-  top: -80px;
-  left: -50px;
-}
-
-.mock-cover::after {
-  width: 180px;
-  height: 180px;
-  bottom: -70px;
-  right: -30px;
-}
-
-.cover-title {
-  display: inline-block;
-  margin-bottom: 0.5rem;
-  background: #fff;
-  color: #265235;
-  border-radius: 999px;
-  padding: 0.35rem 0.9rem;
-  font-weight: 800;
-}
-
-.mock-cover p {
-  max-width: 20ch;
-  line-height: 1.4;
-}
-
-.mock-cover h2 {
-  position: absolute;
-  bottom: 1.2rem;
-  left: 1.2rem;
+.stats p {
   margin: 0;
-  font-size: 2.2rem;
-  color: #fff;
-  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
-@media (max-width: 820px) {
-  .page {
-    grid-template-columns: 1fr;
-    padding-top: 2rem;
+.stats strong {
+  margin-top: 0.35rem;
+  display: block;
+  font-size: 1.7rem;
+}
+
+.market-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.market-card h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.market-card p,
+.market-card small {
+  color: var(--muted);
+}
+
+.card-footer {
+  margin-top: 1.2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.card-footer strong {
+  color: var(--primary);
+}
+
+.features h3,
+.cta h3 {
+  margin-top: 0;
+}
+
+.features ul {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--muted);
+}
+
+.cta {
+  text-align: center;
+}
+
+.cta p {
+  color: var(--muted);
+}
+
+@media (max-width: 860px) {
+  nav {
+    display: none;
   }
 
-  .preview {
-    order: -1;
+  .stats,
+  .market-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,44 +3,80 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ product.name }} | Product Page</title>
+    <title>{{ platform.name }} | Color Prediction Trading</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
   </head>
   <body>
+    <header class="topbar">
+      <div class="brand">{{ platform.name }}</div>
+      <nav>
+        <a href="#markets">Markets</a>
+        <a href="#features">Features</a>
+        <a href="#start">Get Started</a>
+      </nav>
+      <button class="outline-btn">Login</button>
+    </header>
+
     <main class="page">
       <section class="hero">
-        <div class="badge">Back to School Special</div>
-        <h1>{{ product.name }}</h1>
-        <p class="tagline">{{ product.tagline }}</p>
+        <p class="eyebrow">Live Color Prediction Exchange</p>
+        <h1>Trade color outcomes with confidence and speed.</h1>
+        <p class="tagline">{{ platform.tagline }}</p>
 
-        <div class="price-card">
-          <span>Now Available</span>
-          <strong>{{ product.price }}</strong>
-          <small>Per notebook</small>
+        <div class="hero-actions">
+          <button>{{ platform.cta }}</button>
+          <span class="trust">{{ platform.trust_note }}</span>
         </div>
-
-        <ul class="features">
-          <li><span>Size:</span> {{ product.size }}</li>
-          <li><span>Pages:</span> {{ product.pages }}</li>
-          <li><span>Cover:</span> {{ product.cover }}</li>
-          <li><span>Theme:</span> {{ product.theme }}</li>
-        </ul>
-
-        <button>Order Now</button>
       </section>
 
-      <section class="preview" aria-label="Notebook visual preview">
-        <div class="mock-cover">
-          <div class="cover-title">STUDENT</div>
-          <p>Friends of the jungle have gathered to celebrate.</p>
-          <h2>Notebook</h2>
-        </div>
+      <section class="stats" aria-label="Key platform metrics">
+        <article>
+          <p>Daily Volume</p>
+          <strong>{{ platform.daily_volume }}</strong>
+        </article>
+        <article>
+          <p>Success Signals</p>
+          <strong>{{ platform.win_rate }}</strong>
+        </article>
+        <article>
+          <p>Average Payout</p>
+          <strong>{{ platform.avg_payout }}</strong>
+        </article>
+      </section>
+
+      <section class="market-grid" id="markets" aria-label="Active color markets">
+        {% for market in markets %}
+        <article class="market-card">
+          <h2>{{ market.name }}</h2>
+          <p>{{ market.window }}</p>
+          <small>{{ market.trend }}</small>
+          <div class="card-footer">
+            <span>Payout</span>
+            <strong>{{ market.payout }}</strong>
+          </div>
+        </article>
+        {% endfor %}
+      </section>
+
+      <section class="features" id="features">
+        <h3>Why professionals choose us</h3>
+        <ul>
+          <li>AI-assisted probability engine with real-time signal updates</li>
+          <li>Secure wallet, instant deposits, and fast settlement cycles</li>
+          <li>Advanced dashboards for risk management and strategy tuning</li>
+        </ul>
+      </section>
+
+      <section class="cta" id="start">
+        <h3>Ready to launch your first professional trade?</h3>
+        <p>Create your account and start predicting in under two minutes.</p>
+        <button>Create Free Account</button>
       </section>
     </main>
   </body>


### PR DESCRIPTION
### Motivation
- Replace a single-product notebook page with a professional color-prediction trading landing experience and demo data for markets and KPIs.
- Provide a dynamic Flask route that can render platform metrics and a list of active markets so the UI can be driven by server-side data.
- Update visuals to a modern dark “trading dashboard” theme that is clearer for professional users and mobile-responsive.

### Description
- Updated `app.py` to expose a `platform` data model and a `markets` list and to render them via `render_template("index.html", platform=platform, markets=markets)`.
- Replaced the Jinja template at `templates/index.html` with a multi-section layout including top navigation, hero (CTA/trust note), KPI stats, market cards, features, and a signup CTA.
- Rebuilt `static/styles.css` into a dark theme with CSS variables, responsive grid layouts, and component styles for the topbar, hero, stats, market cards, and CTA.
- Updated the static fallback `index.html` to match the new brand copy and hero/stats content so opening the static file mirrors the Flask-rendered experience.

### Testing
- Ran `python -m py_compile app.py` successfully to validate syntax.
- Started the dev server with `python app.py` and confirmed the home page HTML was served by fetching `http://127.0.0.1:8000` with `curl`, which returned the new landing markup.
- Performed a short `timeout` run of `python app.py` to ensure the server starts, which succeeded.
- Attempted to capture a browser screenshot with the Playwright tooling, but the browser process crashed (SIGSEGV) in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0572123c08327a5c42c8a00ecba88)