### PR TITLE
Add period analyzer dashboard with next-period prediction

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,42 +1,119 @@
+from collections import Counter, defaultdict
 from flask import Flask, render_template
 
 app = Flask(__name__)
 
+# Historical rows transcribed from the three provided screenshots.
+# Latest period is first.
+HISTORY_ROWS = [
+    {"period": 20260316100051987, "number": 3},
+    {"period": 20260316100051986, "number": 1},
+    {"period": 20260316100051985, "number": 3},
+    {"period": 20260316100051984, "number": 5},
+    {"period": 20260316100051983, "number": 0},
+    {"period": 20260316100051982, "number": 7},
+    {"period": 20260316100051981, "number": 6},
+    {"period": 20260316100051980, "number": 2},
+    {"period": 20260316100051979, "number": 2},
+    {"period": 20260316100051978, "number": 9},
+    {"period": 20260316100051977, "number": 7},
+    {"period": 20260316100051976, "number": 8},
+    {"period": 20260316100051975, "number": 7},
+    {"period": 20260316100051974, "number": 1},
+    {"period": 20260316100051973, "number": 2},
+    {"period": 20260316100051972, "number": 1},
+    {"period": 20260316100051971, "number": 7},
+    {"period": 20260316100051970, "number": 3},
+    {"period": 20260316100051969, "number": 1},
+    {"period": 20260316100051968, "number": 7},
+    {"period": 20260316100051967, "number": 7},
+    {"period": 20260316100051966, "number": 3},
+    {"period": 20260316100051965, "number": 4},
+    {"period": 20260316100051964, "number": 6},
+    {"period": 20260316100051963, "number": 0},
+    {"period": 20260316100051962, "number": 1},
+    {"period": 20260316100051961, "number": 5},
+    {"period": 20260316100051960, "number": 0},
+    {"period": 20260316100051959, "number": 7},
+]
+
+
+def classify_big_small(number: int) -> str:
+    return "Big" if number >= 5 else "Small"
+
+
+def classify_colors(number: int) -> list[str]:
+    if number in {1, 3, 7, 9}:
+        return ["Green"]
+    if number in {2, 4, 6, 8}:
+        return ["Red"]
+    if number == 0:
+        return ["Red", "Violet"]
+    return ["Green", "Violet"]
+
+
+def enrich_rows(rows: list[dict]) -> list[dict]:
+    return [
+        {
+            **row,
+            "big_small": classify_big_small(row["number"]),
+            "colors": classify_colors(row["number"]),
+        }
+        for row in rows
+    ]
+
+
+def predict_next(rows: list[dict]) -> dict:
+    # Analyze in chronological order to build digit-transition probabilities.
+    chronological = list(reversed(rows))
+    transition_counts: dict[int, Counter] = defaultdict(Counter)
+
+    for current, nxt in zip(chronological, chronological[1:]):
+        transition_counts[current["number"]][nxt["number"]] += 1
+
+    latest = rows[0]
+    next_period = latest["period"] + 1
+    current_digit = latest["number"]
+
+    transitions_from_current = transition_counts.get(current_digit, Counter())
+    if transitions_from_current:
+        predicted_number, confidence_votes = transitions_from_current.most_common(1)[0]
+        confidence = confidence_votes / sum(transitions_from_current.values())
+        method = "Transition model from observed history"
+    else:
+        global_counts = Counter(row["number"] for row in rows)
+        predicted_number, confidence_votes = global_counts.most_common(1)[0]
+        confidence = confidence_votes / len(rows)
+        method = "Fallback to global frequency"
+
+    predicted_big_small = classify_big_small(predicted_number)
+    predicted_colors = classify_colors(predicted_number)
+
+    return {
+        "next_period": next_period,
+        "predicted_number": predicted_number,
+        "predicted_big_small": predicted_big_small,
+        "predicted_colors": predicted_colors,
+        "confidence": round(confidence * 100, 1),
+        "method": method,
+    }
+
 
 @app.route("/")
 def home():
-    platform = {
-        "name": "Chromex Predict Pro",
-        "tagline": "Professional color prediction trading platform built for fast decisions and transparent analytics.",
-        "cta": "Start Trading",
-        "trust_note": "Trusted by 25,000+ active traders",
-        "daily_volume": "$2.4M",
-        "win_rate": "87.3%",
-        "avg_payout": "1.92x",
+    enriched = enrich_rows(HISTORY_ROWS)
+    prediction = predict_next(HISTORY_ROWS)
+
+    summary = {
+        "rows": len(HISTORY_ROWS),
+        "big_count": sum(1 for row in enriched if row["big_small"] == "Big"),
+        "small_count": sum(1 for row in enriched if row["big_small"] == "Small"),
+        "green_hits": sum(1 for row in enriched if "Green" in row["colors"]),
+        "red_hits": sum(1 for row in enriched if "Red" in row["colors"]),
+        "violet_hits": sum(1 for row in enriched if "Violet" in row["colors"]),
     }
 
-    markets = [
-        {
-            "name": "Emerald Sprint",
-            "window": "30 sec round",
-            "trend": "Green momentum +12%",
-            "payout": "1.8x",
-        },
-        {
-            "name": "Crimson Pulse",
-            "window": "60 sec round",
-            "trend": "Red reversal setup",
-            "payout": "2.1x",
-        },
-        {
-            "name": "Violet Edge",
-            "window": "90 sec round",
-            "trend": "High-volatility breakout",
-            "payout": "2.4x",
-        },
-    ]
-
-    return render_template("index.html", platform=platform, markets=markets)
+    return render_template("index.html", rows=enriched, prediction=prediction, summary=summary)
 
 
 if __name__ == "__main__":

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,12 +1,11 @@
 :root {
-  --bg: #060a16;
-  --surface: #111830;
-  --surface-2: #1a2342;
-  --primary: #5cf6d0;
-  --accent: #7d84ff;
-  --text: #eaf0ff;
-  --muted: #9ea7c3;
-  --line: #2b345b;
+  --bg: #111319;
+  --panel: #1d2027;
+  --panel-soft: #242833;
+  --line: #343946;
+  --text: #f5f7ff;
+  --muted: #b7bed3;
+  --accent: #5a8bff;
 }
 
 * {
@@ -15,191 +14,103 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Inter", system-ui, sans-serif;
   color: var(--text);
-  background: radial-gradient(circle at 15% 10%, #1a2550 0%, #060a16 50%, #03050f 100%);
+  background: radial-gradient(circle at top left, #212738 0%, #111319 45%, #0d0f14 100%);
 }
 
-.topbar,
-.page {
-  width: min(1120px, 92vw);
-  margin: 0 auto;
-}
-
-.topbar {
-  padding: 1.2rem 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.container {
+  width: min(1000px, 92vw);
+  margin: 2rem auto;
+  display: grid;
   gap: 1rem;
 }
 
-.brand {
-  font-weight: 800;
-  letter-spacing: 0.02em;
-}
-
-nav {
-  display: flex;
-  gap: 1.2rem;
-}
-
-nav a {
-  color: var(--muted);
-  text-decoration: none;
-  font-size: 0.95rem;
-}
-
-.outline-btn,
-button {
-  border: 1px solid transparent;
-  cursor: pointer;
-  font-weight: 700;
-  border-radius: 12px;
-}
-
-.outline-btn {
-  background: transparent;
-  color: var(--text);
-  border-color: var(--line);
-  padding: 0.55rem 1rem;
-}
-
-.page {
-  padding: 2rem 0 3rem;
-  display: grid;
-  gap: 1.4rem;
-}
-
-.hero {
-  background: linear-gradient(120deg, #1a2342 0%, #0e1530 100%);
+.hero,
+.prediction-card,
+.summary-grid article,
+.table-wrap {
+  background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 20px;
-  padding: 2rem;
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
 }
 
-.eyebrow {
+.chip {
+  width: fit-content;
+  padding: 0.3rem 0.6rem;
+  background: rgba(90, 139, 255, 0.2);
+  color: #b8cbff;
+  border: 1px solid #4869ba;
+  border-radius: 999px;
+  font-size: 0.8rem;
   margin: 0;
-  color: var(--primary);
-  font-weight: 700;
+}
+
+h1,
+h2 {
+  margin: 0.5rem 0;
+}
+
+p {
+  color: var(--muted);
+}
+
+.prediction-grid,
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.prediction-grid article {
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+}
+
+span {
+  display: block;
+  color: var(--muted);
   font-size: 0.85rem;
 }
 
-.hero h1 {
-  margin: 0.75rem 0;
-  font-size: clamp(2rem, 4vw, 3rem);
-  max-width: 20ch;
+strong {
+  font-size: 1.25rem;
 }
 
-.tagline {
-  color: var(--muted);
-  max-width: 58ch;
-  line-height: 1.6;
+.number,
+.num {
+  color: #79fbb5;
+  font-weight: 800;
 }
 
-.hero-actions {
-  margin-top: 1.4rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.9rem;
-  align-items: center;
-}
-
-button {
-  background: linear-gradient(130deg, var(--primary), #87ffe5);
-  color: #02241d;
-  padding: 0.75rem 1.15rem;
-}
-
-.trust {
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.stats {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-}
-
-.stats article,
-.market-card,
-.features,
-.cta {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  padding: 1.2rem;
-}
-
-.stats p {
-  margin: 0;
-  color: var(--muted);
+.meta {
+  margin-bottom: 0;
   font-size: 0.9rem;
 }
 
-.stats strong {
-  margin-top: 0.35rem;
-  display: block;
-  font-size: 1.7rem;
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.6rem;
 }
 
-.market-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+th,
+td {
+  text-align: left;
+  padding: 0.7rem 0.5rem;
+  border-bottom: 1px solid var(--line);
 }
 
-.market-card h2 {
-  margin: 0;
-  font-size: 1.2rem;
+th {
+  color: #d9e1ff;
 }
 
-.market-card p,
-.market-card small {
-  color: var(--muted);
-}
-
-.card-footer {
-  margin-top: 1.2rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.card-footer strong {
-  color: var(--primary);
-}
-
-.features h3,
-.cta h3 {
-  margin-top: 0;
-}
-
-.features ul {
-  margin: 0;
-  padding-left: 1rem;
-  display: grid;
-  gap: 0.6rem;
-  color: var(--muted);
-}
-
-.cta {
-  text-align: center;
-}
-
-.cta p {
-  color: var(--muted);
-}
-
-@media (max-width: 860px) {
-  nav {
-    display: none;
-  }
-
-  .stats,
-  .market-grid {
-    grid-template-columns: 1fr;
+@media (max-width: 640px) {
+  th,
+  td {
+    font-size: 0.88rem;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ platform.name }} | Color Prediction Trading</title>
+    <title>Period Analyzer Pro</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -13,70 +13,71 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
   </head>
   <body>
-    <header class="topbar">
-      <div class="brand">{{ platform.name }}</div>
-      <nav>
-        <a href="#markets">Markets</a>
-        <a href="#features">Features</a>
-        <a href="#start">Get Started</a>
-      </nav>
-      <button class="outline-btn">Login</button>
-    </header>
+    <main class="container">
+      <header class="hero">
+        <p class="chip">3 screenshot analysis</p>
+        <h1>Next Period Predictor</h1>
+        <p>
+          A simple professional dashboard that analyzes period, number, big/small, and color history,
+          then predicts the next period result.
+        </p>
+      </header>
 
-    <main class="page">
-      <section class="hero">
-        <p class="eyebrow">Live Color Prediction Exchange</p>
-        <h1>Trade color outcomes with confidence and speed.</h1>
-        <p class="tagline">{{ platform.tagline }}</p>
-
-        <div class="hero-actions">
-          <button>{{ platform.cta }}</button>
-          <span class="trust">{{ platform.trust_note }}</span>
+      <section class="prediction-card">
+        <h2>Predicted Next Result</h2>
+        <div class="prediction-grid">
+          <article>
+            <span>Next Period</span>
+            <strong>{{ prediction.next_period }}</strong>
+          </article>
+          <article>
+            <span>Number</span>
+            <strong class="number">{{ prediction.predicted_number }}</strong>
+          </article>
+          <article>
+            <span>Big / Small</span>
+            <strong>{{ prediction.predicted_big_small }}</strong>
+          </article>
+          <article>
+            <span>Color</span>
+            <strong>{{ prediction.predicted_colors | join(' + ') }}</strong>
+          </article>
         </div>
+        <p class="meta">
+          Confidence: <b>{{ prediction.confidence }}%</b> · Method: {{ prediction.method }}
+        </p>
       </section>
 
-      <section class="stats" aria-label="Key platform metrics">
-        <article>
-          <p>Daily Volume</p>
-          <strong>{{ platform.daily_volume }}</strong>
-        </article>
-        <article>
-          <p>Success Signals</p>
-          <strong>{{ platform.win_rate }}</strong>
-        </article>
-        <article>
-          <p>Average Payout</p>
-          <strong>{{ platform.avg_payout }}</strong>
-        </article>
+      <section class="summary-grid">
+        <article><span>Total Rows</span><strong>{{ summary.rows }}</strong></article>
+        <article><span>Big / Small</span><strong>{{ summary.big_count }} / {{ summary.small_count }}</strong></article>
+        <article><span>Green Hits</span><strong>{{ summary.green_hits }}</strong></article>
+        <article><span>Red Hits</span><strong>{{ summary.red_hits }}</strong></article>
+        <article><span>Violet Hits</span><strong>{{ summary.violet_hits }}</strong></article>
       </section>
 
-      <section class="market-grid" id="markets" aria-label="Active color markets">
-        {% for market in markets %}
-        <article class="market-card">
-          <h2>{{ market.name }}</h2>
-          <p>{{ market.window }}</p>
-          <small>{{ market.trend }}</small>
-          <div class="card-footer">
-            <span>Payout</span>
-            <strong>{{ market.payout }}</strong>
-          </div>
-        </article>
-        {% endfor %}
-      </section>
-
-      <section class="features" id="features">
-        <h3>Why professionals choose us</h3>
-        <ul>
-          <li>AI-assisted probability engine with real-time signal updates</li>
-          <li>Secure wallet, instant deposits, and fast settlement cycles</li>
-          <li>Advanced dashboards for risk management and strategy tuning</li>
-        </ul>
-      </section>
-
-      <section class="cta" id="start">
-        <h3>Ready to launch your first professional trade?</h3>
-        <p>Create your account and start predicting in under two minutes.</p>
-        <button>Create Free Account</button>
+      <section class="table-wrap">
+        <h2>Analyzed History</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Period</th>
+              <th>Number</th>
+              <th>Big/Small</th>
+              <th>Color</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in rows %}
+            <tr>
+              <td>{{ row.period }}</td>
+              <td class="num">{{ row.number }}</td>
+              <td>{{ row.big_small }}</td>
+              <td>{{ row.colors | join(' + ') }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </section>
     </main>
   </body>


### PR DESCRIPTION
### Motivation

- Provide a compact web dashboard that analyzes the period/number data extracted from three screenshots and predicts the next period's number, big/small value, and color.
- Deliver a simple, professional UI so the prediction and recent history are easy to review at a glance.

### Description

- Added a transcribed history `HISTORY_ROWS` and analysis logic to `app.py`, including `classify_big_small`, `classify_colors`, `enrich_rows`, and a transition-based `predict_next` function that returns number, big/small, colors, confidence, and method. 
- Updated the root route in `app.py` to render the prediction, enriched rows, and summary statistics to the template. 
- Replaced the landing template with `templates/index.html`, a focused dashboard showing the predicted next period, summary metrics, and a full analyzed history table. 
- Restyled the UI via `static/styles.css` for a clean dark professional layout and responsive card/grid components. 

### Testing

- Ran a syntax check with `python -m py_compile app.py`, which succeeded. 
- Performed a server startup smoke test with `timeout 3s python app.py`, which started and served HTTP responses. 
- Verified HTTP response with `nohup python app.py ... && curl -sSf http://127.0.0.1:8000 | head -n 20`, which returned the dashboard HTML. 
- Executed the prediction function with `from app import predict_next,HISTORY_ROWS; print(predict_next(HISTORY_ROWS))`, which returned `{'next_period': 20260316100051988, 'predicted_number': 7, 'predicted_big_small': 'Big', 'predicted_colors': ['Green'], 'confidence': 66.7, 'method': 'Transition model from observed history'}`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b831c82348832792ec446daef128ef)